### PR TITLE
workaround for https://github.com/JehanneOS/jehanne/issues/13

### DIFF
--- a/cross/init.sh
+++ b/cross/init.sh
@@ -74,6 +74,7 @@ failOnError $? "fetching sources"
 if [ ! -f tmp/bin/m4 ]; then
 (
 	cd src/m4 &&
+	patch -p1 < ../../patch/m4/m4-1.4.14-glibc-change-work-around.patch &&
 	sed -i '/_GL_WARN_ON_USE (gets/d' lib/stdio.in.h &&
 	( grep -q '#include <sys/stat.h>'  src/m4.h || sed -i 's:.*\#include <sys/types\.h>.*:&\n#include <sys/stat.h>:g' src/m4.h ) &&
 	./configure --prefix=$JEHANNE/hacking/cross/tmp &&

--- a/cross/patch/m4/m4-1.4.14-glibc-change-work-around.patch
+++ b/cross/patch/m4/m4-1.4.14-glibc-change-work-around.patch
@@ -1,0 +1,116 @@
+diff -Naur m4-orig/lib/fflush.c m4/lib/fflush.c
+--- m4-orig/lib/fflush.c	2020-09-12 14:37:51.600799148 +0200
++++ m4/lib/fflush.c	2020-09-12 14:40:44.292795458 +0200
+@@ -31,7 +31,7 @@
+ #undef fflush
+ 
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+ /* Clear the stream's ungetc buffer, preserving the value of ftello (fp).  */
+ static inline void
+@@ -138,7 +138,7 @@
+   if (stream == NULL || ! freading (stream))
+     return fflush (stream);
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+   clear_ungetc_buffer_preserving_position (stream);
+ 
+diff -Naur m4-orig/lib/fpurge.c m4/lib/fpurge.c
+--- m4-orig/lib/fpurge.c	2020-09-12 14:37:51.632799148 +0200
++++ m4/lib/fpurge.c	2020-09-12 14:41:36.832794335 +0200
+@@ -61,7 +61,7 @@
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_IO_read_end = fp->_IO_read_ptr;
+   fp->_IO_write_ptr = fp->_IO_write_base;
+   /* Avoid memory leak when there is an active ungetc buffer.  */
+diff -Naur m4-orig/lib/freadahead.c m4/lib/freadahead.c
+--- m4-orig/lib/freadahead.c	2020-09-12 14:37:51.572799149 +0200
++++ m4/lib/freadahead.c	2020-09-12 14:40:20.052795976 +0200
+@@ -25,7 +25,7 @@
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)
+diff -Naur m4-orig/lib/freading.c m4/lib/freading.c
+--- m4-orig/lib/freading.c	2020-09-12 14:37:51.600799148 +0200
++++ m4/lib/freading.c	2020-09-12 14:40:26.496795838 +0200
+@@ -31,7 +31,7 @@
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return ((fp->_flags & _IO_NO_WRITES) != 0
+           || ((fp->_flags & (_IO_NO_READS | _IO_CURRENTLY_PUTTING)) == 0
+               && fp->_IO_read_base != NULL));
+diff -Naur m4-orig/lib/fseeko.c m4/lib/fseeko.c
+--- m4-orig/lib/fseeko.c	2020-09-12 14:37:51.572799149 +0200
++++ m4/lib/fseeko.c	2020-09-12 14:40:32.032795720 +0200
+@@ -41,7 +41,7 @@
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -107,7 +107,7 @@
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+ #elif defined __sferror || defined __DragonFly__ /* FreeBSD, NetBSD, OpenBSD, DragonFly, MacOS X, Cygwin */
+ # if defined __CYGWIN__
+diff -Naur m4-orig/lib/stdio-impl.h m4/lib/stdio-impl.h
+--- m4-orig/lib/stdio-impl.h
++++ m4/lib/stdio-impl.h
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */
+ 
+--- m4-new/Makefile.am	2020-09-12 14:58:09.544773119 +0200
++++ m4/Makefile.am	2020-09-12 14:58:31.104772658 +0200
+@@ -20,7 +20,7 @@
+ ##
+ ## Written by Gary V. Vaughan <gary@gnu.org>
+ 
+-SUBDIRS = . examples lib src doc checks tests
++SUBDIRS = . examples lib src checks tests
+ 
+ syntax_check_exceptions =		\
+   .x-sc_prohibit_tab_based_indentation	\
+--- m4/Makefile.in	2020-09-12 15:02:23.100767700 +0200
++++ m4-new/Makefile.in	2020-09-12 15:02:13.312767909 +0200
+@@ -904,7 +904,7 @@
+ top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+-SUBDIRS = . examples lib src doc checks tests
++SUBDIRS = . examples lib src checks tests
+ syntax_check_exceptions = \
+   .x-sc_prohibit_tab_based_indentation	\
+   .x-update-copyright


### PR DESCRIPTION
m4 build for debian buster works when
- applying a patch found elsewhere
- suppressing texinfo build